### PR TITLE
Update to the latest Fiji components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,21 @@
 		</contributor>
 	</contributors>
 
+	<scm>
+		<connection>scm:git:git://github.com/saalfeldlab/bigwarp</connection>
+		<developerConnection>scm:git:git@github.com:saalfeldlab/bigwarp</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/saalfeldlab/bigwarp</url>
+	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/saalfeldlab/bigwarp/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Jenkins</system>
+		<url>http://jenkins.imagej.net/job/bigwarp/</url>
+	</ciManagement>
+
 	<repositories>
 		<repository>
 			<id>imagej.public</id>

--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>
-				com.googlecode.efficient-java-matrix-library
-			</groupId>
+			<groupId>com.googlecode.efficient-java-matrix-library</groupId>
 			<artifactId>ejml</artifactId>
 			<version>0.24</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,9 @@
 
 	<parent>
 		<groupId>sc.fiji</groupId>
-		<artifactId>pom-bigdataviewer</artifactId>
-		<version>2.2.2</version>
+		<artifactId>pom-fiji</artifactId>
+		<version>19.0.0</version>
+		<relativePath />
 	</parent>
 
 	<artifactId>bigwarp_fiji</artifactId>
@@ -93,6 +94,10 @@
 		<url>http://jenkins.imagej.net/job/bigwarp/</url>
 	</ciManagement>
 
+	<properties>
+		<scijava.jvm.version>1.7</scijava.jvm.version>
+	</properties>
+
 	<repositories>
 		<repository>
 			<id>imagej.public</id>
@@ -100,6 +105,17 @@
 		</repository>
 	</repositories>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>sc.fiji</groupId>
+				<artifactId>pom-bigdataviewer</artifactId>
+				<version>${pom-bigdataviewer.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>com.googlecode.efficient-java-matrix-library</groupId>


### PR DESCRIPTION
This extends pom-fiji (rather than pom-bigdataviewer) version 19.0.0.

In particular, it upgrades to the SciJava fork of Java 3D 1.6, which requires Java 7. Hence, BigWarp now requires Java 7, too. I hope this is OK—ImageJ as a whole will be moving to Java 8 quite soon, and this week's updates are a step toward that goal.