### PR TITLE
Use imagej.net URL for all developers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,7 @@
 		<developer>
 			<id>bogovicj</id>
 			<name>John Bogovic</name>
-			<email>bogovicj@janelia.hhmi.org</email>
-			<url>http://www.janelia.org/lab/saalfeld-lab</url>
-			<organization>HHMI Janelia Research Campus</organization>
-			<organizationUrl>http://www.janelia.org/</organizationUrl>
+			<url>http://imagej.net/User:Bogovic</url>
 			<roles>
 				<role>founder</role>
 				<role>lead</role>
@@ -46,10 +43,7 @@
 		<developer>
 			<id>axtimwalde</id>
 			<name>Stephan Saalfeld</name>
-			<email>saalfelds@janelia.hhmi.org</email>
-			<url>http://www.janelia.org/lab/saalfeld-lab</url>
-			<organization>HHMI Janelia Research Campus</organization>
-			<organizationUrl>http://www.janelia.org/</organizationUrl>
+			<url>http://imagej.net/User:Saalfeld</url>
 			<roles>
 				<role>founder</role>
 				<role>lead</role>
@@ -59,22 +53,17 @@
 				<role>support</role>
 				<role>maintainer</role>
 			</roles>
-			<timezone>-5</timezone>
 		</developer>
 	</developers>
 	<contributors>
 		<contributor>
 			<name>Curtis Rueden</name>
-			<url>http://loci.wisc.edu/people/curtis-rueden</url>
-			<organization>UW-Madison LOCI</organization>
-			<organizationUrl>http://loci.wisc.edu/</organizationUrl>
+			<url>http://imagej.net/User:Rueden</url>
 			<properties><id>ctrueden</id></properties>
 		</contributor>
 		<contributor>
 			<name>Mark Hiner</name>
-			<url>http://loci.wisc.edu/people/mark-hiner</url>
-			<organization>UW-Madison LOCI</organization>
-			<organizationUrl>http://loci.wisc.edu/</organizationUrl>
+			<url>http://imagej.net/User:Hinerm</url>
 			<properties><id>hinerm</id></properties>
 		</contributor>
 	</contributors>


### PR DESCRIPTION
And remove the other info, which is prone to obsolescence.

This information is available from imagej.net user profiles, in an indirect way which can be updated in case it changes, rather than being baked into the POM forever.

This change will make automatic generation of informational sidebars on the wiki easier to accomplish.
