### PR TITLE
bump to pom-bigdataviewer 4.0.1 versions and fix compile errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,10 @@
 		</repository>
 	</repositories>
 
+	<properties>
+		<pom-bigdataviewer.version>4.0.1</pom-bigdataviewer.version>
+	</properties>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/src/main/java/bdv/gui/BigWarpViewerFrame.java
+++ b/src/main/java/bdv/gui/BigWarpViewerFrame.java
@@ -13,18 +13,18 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import org.scijava.ui.behaviour.MouseAndKeyHandler;
+import org.scijava.ui.behaviour.util.InputActionBindings;
+import org.scijava.ui.behaviour.util.TriggerBehaviourBindings;
 
-import net.imglib2.ui.TransformEventHandler;
-import net.imglib2.ui.util.GuiUtil;
 import bdv.BehaviourTransformEventHandler;
-import bdv.img.cache.Cache;
+import bdv.cache.CacheControl;
 import bdv.viewer.BigWarpViewerPanel;
 import bdv.viewer.BigWarpViewerSettings;
-import bdv.viewer.InputActionBindings;
 import bdv.viewer.SourceAndConverter;
-import bdv.viewer.TriggerBehaviourBindings;
 import bdv.viewer.ViewerOptions;
 import bigwarp.BigWarp;
+import net.imglib2.ui.TransformEventHandler;
+import net.imglib2.ui.util.GuiUtil;
 
 public class BigWarpViewerFrame extends JFrame
 {
@@ -44,7 +44,7 @@ public class BigWarpViewerFrame extends JFrame
 			final int width, final int height,
 			final List< SourceAndConverter< ? > > sources,
 			final BigWarpViewerSettings viewerSettings,
-			final Cache cache,
+			final CacheControl cache,
 			final String title,
 			final boolean isMoving,
 			final int[] movingIndexList,
@@ -58,7 +58,7 @@ public class BigWarpViewerFrame extends JFrame
 			final int width, final int height,
 			final List< SourceAndConverter< ? > > sources,
 			final BigWarpViewerSettings viewerSettings,
-			final Cache cache,
+			final CacheControl cache,
 			final ViewerOptions optional,
 			final String title,
 			final boolean isMoving,

--- a/src/main/java/bdv/img/RenamableSource.java
+++ b/src/main/java/bdv/img/RenamableSource.java
@@ -49,12 +49,6 @@ public class RenamableSource< T > implements Source< T >
 	}
 
 	@Override
-	public AffineTransform3D getSourceTransform( int t, int level )
-	{
-		return src.getSourceTransform( t, level );
-	}
-
-	@Override
 	public T getType()
 	{
 		return src.getType();

--- a/src/main/java/bdv/img/WarpedSource.java
+++ b/src/main/java/bdv/img/WarpedSource.java
@@ -1,13 +1,13 @@
 package bdv.img;
 
-import jitk.spline.ThinPlateR2LogRSplineKernelTransform;
-import bdv.img.cache.CacheHints;
+import bdv.cache.CacheHints;
 import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.render.DefaultMipmapOrdering;
 import bdv.viewer.render.MipmapOrdering;
 import bdv.viewer.render.SetCacheHints;
+import jitk.spline.ThinPlateR2LogRSplineKernelTransform;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
@@ -126,15 +126,6 @@ public class WarpedSource < T > implements Source< T >, MipmapOrdering, SetCache
 			transform.identity();
 		else
 			source.getSourceTransform( t, level, transform );
-	}
-
-	@Override
-	public AffineTransform3D getSourceTransform( final int t, final int level )
-	{
-		if( isTransformed )
-			return new AffineTransform3D();
-		else
-			return source.getSourceTransform( t, level );
 	}
 
 	@Override

--- a/src/main/java/bdv/viewer/BigWarpLandmarkFrame.java
+++ b/src/main/java/bdv/viewer/BigWarpLandmarkFrame.java
@@ -8,9 +8,11 @@ import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
-import net.imglib2.ui.util.GuiUtil;
+import org.scijava.ui.behaviour.util.InputActionBindings;
+
 import bdv.gui.BigWarpLandmarkPanel;
 import bigwarp.BigWarp;
+import net.imglib2.ui.util.GuiUtil;
 
 public class BigWarpLandmarkFrame extends JFrame {
 

--- a/src/main/java/bdv/viewer/BigWarpViewerPanel.java
+++ b/src/main/java/bdv/viewer/BigWarpViewerPanel.java
@@ -8,21 +8,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import bdv.cache.CacheControl;
+import bdv.img.WarpedSource;
+import bdv.util.Affine3DHelpers;
+import bdv.util.Prefs;
+import bdv.viewer.animate.OverlayAnimator;
+import bdv.viewer.animate.RotationAnimator2D;
+import bdv.viewer.animate.SimilarityTransformAnimator2D;
+import bdv.viewer.animate.SimilarityTransformAnimator3D;
+import bdv.viewer.state.SourceState;
 import net.imglib2.RealPoint;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.util.LinAlgHelpers;
-import bdv.img.WarpedSource;
-import bdv.img.cache.Cache;
-import bdv.util.Affine3DHelpers;
-import bdv.util.Prefs;
-import bdv.viewer.SourceAndConverter;
-import bdv.viewer.ViewerPanel;
-import bdv.viewer.animate.OverlayAnimator;
-import bdv.viewer.animate.RotationAnimator;
-import bdv.viewer.animate.RotationAnimator2D;
-import bdv.viewer.animate.SimilarityTransformAnimator3D;
-import bdv.viewer.animate.SimilarityTransformAnimator2D;
-import bdv.viewer.state.SourceState;
 
 public class BigWarpViewerPanel extends ViewerPanel
 {
@@ -59,13 +56,13 @@ public class BigWarpViewerPanel extends ViewerPanel
 	
 	ViewerOptions options;
 	
-	public BigWarpViewerPanel( final List< SourceAndConverter< ? > > sources, final BigWarpViewerSettings viewerSettings, final Cache cache, boolean isMoving,
+	public BigWarpViewerPanel( final List< SourceAndConverter< ? > > sources, final BigWarpViewerSettings viewerSettings, final CacheControl cache, boolean isMoving,
 			int[] movingSourceIndexList, int[] targetSourceIndexList )
 	{
 		this( sources, viewerSettings, cache, ViewerOptions.options(), isMoving, movingSourceIndexList, targetSourceIndexList );
 	}
 	
-	public BigWarpViewerPanel( final List< SourceAndConverter< ? > > sources, final BigWarpViewerSettings viewerSettings, final Cache cache, final ViewerOptions optional, boolean isMoving, 
+	public BigWarpViewerPanel( final List< SourceAndConverter< ? > > sources, final BigWarpViewerSettings viewerSettings, final CacheControl cache, final ViewerOptions optional, boolean isMoving, 
 			int[] movingSourceIndexList, int[] targetSourceIndexList  )
 	{
 		super( sources, 1, cache, optional );

--- a/src/main/java/bdv/viewer/WarpNavigationActions.java
+++ b/src/main/java/bdv/viewer/WarpNavigationActions.java
@@ -6,12 +6,9 @@ import javax.swing.ActionMap;
 import javax.swing.InputMap;
 
 import org.scijava.ui.behaviour.KeyStrokeAdder;
+import org.scijava.ui.behaviour.util.AbstractNamedAction;
+import org.scijava.ui.behaviour.util.InputActionBindings;
 
-import bdv.util.AbstractNamedAction;
-import bdv.util.AbstractNamedAction.NamedActionAdder;
-import bdv.util.KeyProperties;
-import bdv.viewer.InputActionBindings;
-import bdv.viewer.ViewerPanel;
 import bdv.viewer.ViewerPanel.AlignPlane;
 
 public class WarpNavigationActions 
@@ -46,7 +43,7 @@ public class WarpNavigationActions
 	public static void installActionBindings(
 			final InputActionBindings inputActionBindings,
 			final BigWarpViewerPanel viewer,
-			final KeyProperties keyProperties,
+			final KeyStrokeAdder.Factory keyProperties,
 			final boolean is2d )
 	{
 		inputActionBindings.addActionMap( "navigation", createActionMap( viewer ) );
@@ -55,7 +52,7 @@ public class WarpNavigationActions
 		viewer.getActionMap().get( "navigation" );
 	}
 
-	public static InputMap createInputMap( final KeyProperties keyProperties, boolean is2d )
+	public static InputMap createInputMap( final KeyStrokeAdder.Factory keyProperties, final boolean is2d )
 	{
 		final InputMap inputMap = new InputMap();
 		final KeyStrokeAdder map = keyProperties.keyStrokeAdder( inputMap );
@@ -101,26 +98,23 @@ public class WarpNavigationActions
 
 	public static void addToActionMap( final ActionMap actionMap, final BigWarpViewerPanel viewer, final int numSourceKeys )
 	{
-		final NamedActionAdder map = new NamedActionAdder( actionMap );
-
-		map.put( new ToggleInterPolationAction( viewer ) );
-		map.put( new ToggleFusedModeAction( viewer ) );
-		map.put( new ToggleGroupingAction( viewer ) );
+		new ToggleInterPolationAction( viewer ).put( actionMap );
+		new ToggleFusedModeAction( viewer ).put( actionMap );
+		new ToggleGroupingAction( viewer ).put( actionMap );
 
 		for ( int i = 0; i < numSourceKeys; ++i )
 		{
-			map.put( new SetCurrentSourceOrGroupAction( viewer, i ) );
-			map.put( new ToggleSourceOrGroupVisibilityAction( viewer, i ) );
+			new SetCurrentSourceOrGroupAction( viewer, i ).put( actionMap );
+			new ToggleSourceOrGroupVisibilityAction( viewer, i ).put( actionMap );
 		}
 
 		for ( final AlignPlane plane : AlignPlane.values() )
-			map.put( new AlignPlaneAction( viewer, plane ) );
-		
-		map.put( new RotatePlaneAction( viewer, rotationDirections2d.CLOCKWISE ) ); // clockwise
-		map.put( new RotatePlaneAction( viewer, rotationDirections2d.COUNTERCLOCKWISE ) ); // counterclockwise
+			new AlignPlaneAction( viewer, plane ).put( actionMap );
 
-		
-		map.put( new DisplayXfmAction( viewer ) );
+		new RotatePlaneAction( viewer, rotationDirections2d.CLOCKWISE ).put( actionMap ); // clockwise
+		new RotatePlaneAction( viewer, rotationDirections2d.COUNTERCLOCKWISE ).put( actionMap ); // counterclockwise
+
+		new DisplayXfmAction( viewer ).put( actionMap );
 	}
 
 	private static abstract class NavigationAction extends AbstractNamedAction

--- a/src/main/java/bigwarp/BehaviourTransformEventHandler2D.java
+++ b/src/main/java/bigwarp/BehaviourTransformEventHandler2D.java
@@ -8,9 +8,9 @@ import org.scijava.ui.behaviour.InputTriggerAdder;
 import org.scijava.ui.behaviour.InputTriggerMap;
 import org.scijava.ui.behaviour.ScrollBehaviour;
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
+import org.scijava.ui.behaviour.util.TriggerBehaviourBindings;
 
 import bdv.BehaviourTransformEventHandler;
-import bdv.viewer.TriggerBehaviourBindings;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.ui.TransformEventHandlerFactory;
 import net.imglib2.ui.TransformListener;

--- a/src/main/java/bigwarp/BigWarp.java
+++ b/src/main/java/bigwarp/BigWarp.java
@@ -50,23 +50,23 @@ import org.jdom2.output.XMLOutputter;
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
 
 import bdv.BehaviourTransformEventHandler3D;
+import bdv.BigDataViewer;
 import bdv.ViewerImgLoader;
+import bdv.cache.CacheControl;
 import bdv.export.ProgressWriter;
 import bdv.export.ProgressWriterConsole;
 import bdv.gui.BigWarpLandmarkPanel;
 import bdv.gui.BigWarpViewerFrame;
 import bdv.gui.LandmarkKeyboardProcessor;
 import bdv.img.WarpedSource;
-import bdv.img.cache.Cache;
 import bdv.tools.InitializeViewerState;
 import bdv.tools.VisibilityAndGroupingDialog;
+import bdv.tools.bookmarks.Bookmarks;
+import bdv.tools.bookmarks.BookmarksEditor;
 import bdv.tools.brightness.BrightnessDialog;
 import bdv.tools.brightness.ConverterSetup;
 import bdv.tools.brightness.RealARGBColorConverterSetup;
 import bdv.tools.brightness.SetupAssignments;
-import bdv.tools.bookmarks.Bookmarks;
-import bdv.tools.bookmarks.BookmarksEditor;
-import bdv.util.KeyProperties;
 import bdv.viewer.BigWarpConverterSetupWrapper;
 import bdv.viewer.BigWarpDragOverlay;
 import bdv.viewer.BigWarpLandmarkFrame;
@@ -117,7 +117,6 @@ import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.type.volatiles.VolatileFloatType;
-import net.imglib2.ui.InteractiveDisplayCanvasComponent;
 import net.imglib2.ui.PainterThread;
 import net.imglib2.ui.RenderTarget;
 import net.imglib2.ui.TransformEventHandler;
@@ -297,7 +296,8 @@ public class BigWarp
 		baseXfmList = new AbstractModel< ? >[ 3 ];
 		setupWarpMagBaselineOptions( baseXfmList, ndims );
 
-		fixedViewXfm = sources.get( targetSourceIndexList[ 0 ] ).getSpimSource().getSourceTransform( 0, 0 );
+		fixedViewXfm = new AffineTransform3D();
+		sources.get( targetSourceIndexList[ 0 ] ).getSpimSource().getSourceTransform( 0, 0, fixedViewXfm );
 
 		warpMagSourceIndex = addWarpMagnitudeSource( sources, converterSetups, "WarpMagnitudeSource", data );
 		gridSourceIndex = addGridSource( sources, converterSetups, "GridSource", data );
@@ -313,14 +313,14 @@ public class BigWarp
 		viewerSettings = new BigWarpViewerSettings();
 
 		// Viewer frame for the moving image
-		viewerFrameP = new BigWarpViewerFrame( this, DEFAULT_WIDTH, DEFAULT_HEIGHT, sources, viewerSettings, 
-				( ( ViewerImgLoader ) data.seqP.getImgLoader() ).getCache(), optionsP, "Bigwarp moving image", true, movingSourceIndexList, targetSourceIndexList );
+		viewerFrameP = new BigWarpViewerFrame( this, DEFAULT_WIDTH, DEFAULT_HEIGHT, sources, viewerSettings,
+				( ( ViewerImgLoader ) data.seqP.getImgLoader() ).getCacheControl(), optionsP, "Bigwarp moving image", true, movingSourceIndexList, targetSourceIndexList );
 
 		viewerP = getViewerFrameP().getViewerPanel();
 
 		// Viewer frame for the fixed image
-		viewerFrameQ = new BigWarpViewerFrame( this, DEFAULT_WIDTH, DEFAULT_HEIGHT, sources, viewerSettings, 
-				( ( ViewerImgLoader ) data.seqQ.getImgLoader() ).getCache(), optionsQ, "Bigwarp fixed image", false, movingSourceIndexList, targetSourceIndexList );
+		viewerFrameQ = new BigWarpViewerFrame( this, DEFAULT_WIDTH, DEFAULT_HEIGHT, sources, viewerSettings,
+				( ( ViewerImgLoader ) data.seqQ.getImgLoader() ).getCacheControl(), optionsQ, "Bigwarp fixed image", false, movingSourceIndexList, targetSourceIndexList );
 
 		viewerQ = getViewerFrameQ().getViewerPanel();
 
@@ -440,7 +440,7 @@ public class BigWarp
 																// before action
 																// maps are made
 
-		final KeyProperties keyProperties = KeyProperties.readPropertyFile();
+		final InputTriggerConfig keyProperties = BigDataViewer.getInputTriggerConfig( null );
 		WarpNavigationActions.installActionBindings( getViewerFrameP().getKeybindings(), viewerP, keyProperties, ( ndims == 2 ) );
 		BigWarpActions.installActionBindings( getViewerFrameP().getKeybindings(), this, keyProperties );
 
@@ -1539,7 +1539,7 @@ public class BigWarp
 		final MyTarget target = new MyTarget();
 		final int numRenderThreads = 1;
 
-		final MultiResolutionRenderer renderer = new MultiResolutionRenderer( target, new PainterThread( null ), new double[] { 1 }, 0, false, numRenderThreads, null, false, viewerP.getOptionValues().getAccumulateProjectorFactory(), new Cache.Dummy() );
+		final MultiResolutionRenderer renderer = new MultiResolutionRenderer( target, new PainterThread( null ), new double[] { 1 }, 0, false, numRenderThreads, null, false, viewerP.getOptionValues().getAccumulateProjectorFactory(), new CacheControl.Dummy() );
 
 		progressWriter.setProgress( 0 );
 

--- a/src/main/java/bigwarp/BigWarpActions.java
+++ b/src/main/java/bigwarp/BigWarpActions.java
@@ -12,17 +12,14 @@ import javax.swing.KeyStroke;
 import javax.swing.table.TableCellEditor;
 
 import org.scijava.ui.behaviour.KeyStrokeAdder;
+import org.scijava.ui.behaviour.util.AbstractNamedAction;
+import org.scijava.ui.behaviour.util.InputActionBindings;
 
-import mpicbg.models.AbstractModel;
 import bdv.gui.BigWarpViewerFrame;
 import bdv.tools.ToggleDialogAction;
-import bdv.util.AbstractNamedAction;
-import bdv.util.AbstractNamedAction.NamedActionAdder;
-import bdv.util.KeyProperties;
-import bdv.viewer.BigWarpViewerPanel;
-import bdv.viewer.InputActionBindings;
 import bigwarp.landmarks.LandmarkTableModel;
 import bigwarp.source.GridSource;
+import mpicbg.models.AbstractModel;
 
 public class BigWarpActions
 {
@@ -89,7 +86,7 @@ public class BigWarpActions
 	public static void installActionBindings(
 			final InputActionBindings inputActionBindings,
 			final BigWarp bw,
-			final KeyProperties keyProperties )
+			final KeyStrokeAdder.Factory keyProperties )
 	{
 		inputActionBindings.addActionMap( "bw", createActionMap( bw ) );
 		inputActionBindings.addActionMap( "bwv", createActionMapViewer( bw ) );
@@ -101,7 +98,7 @@ public class BigWarpActions
 			final InputActionBindings inputActionBindings,
 			final BigWarp bw,
 			final JTable landmarkTable,
-			final KeyProperties keyProperties )
+			final KeyStrokeAdder.Factory keyProperties )
 	{
 		inputActionBindings.addActionMap( "bw", createActionMap( bw ) );
 		inputActionBindings.addInputMap( "bw", createInputMap( keyProperties ) );
@@ -118,7 +115,7 @@ public class BigWarpActions
 		parentInputMap.put(   enterUpKS, "released" );
 	}
 
-	public static InputMap createInputMapViewer( final KeyProperties keyProperties )
+	public static InputMap createInputMapViewer( final KeyStrokeAdder.Factory keyProperties )
 	{
 		final InputMap inputMap = new InputMap();
 		final KeyStrokeAdder map = keyProperties.keyStrokeAdder( inputMap );
@@ -148,40 +145,40 @@ public class BigWarpActions
 	public static ActionMap createActionMapViewer( final BigWarp bw )
 	{
 		final ActionMap actionMap = new ActionMap();
-		final NamedActionAdder map = new NamedActionAdder( actionMap );
 
-		map.put( new ToggleDialogAction( String.format( VISIBILITY_AND_GROUPING, "moving" ), bw.activeSourcesDialogP ) );
-		map.put( new ToggleDialogAction( String.format( VISIBILITY_AND_GROUPING, "target" ), bw.activeSourcesDialogQ ) );
+		new ToggleDialogAction( String.format( VISIBILITY_AND_GROUPING, "moving" ), bw.activeSourcesDialogP ).put( actionMap );
+		new ToggleDialogAction( String.format( VISIBILITY_AND_GROUPING, "moving" ), bw.activeSourcesDialogP ).put( actionMap );
+		new ToggleDialogAction( String.format( VISIBILITY_AND_GROUPING, "target" ), bw.activeSourcesDialogQ ).put( actionMap );
 
-		for( BigWarp.WarpVisType t: BigWarp.WarpVisType.values())
+		for( final BigWarp.WarpVisType t: BigWarp.WarpVisType.values())
 		{
-			map.put( new SetWarpVisTypeAction( t, bw ));
-			map.put( new SetWarpVisTypeAction( t, bw, bw.getViewerFrameP() ));
-			map.put( new SetWarpVisTypeAction( t, bw, bw.getViewerFrameQ() ));
+			new SetWarpVisTypeAction( t, bw ).put( actionMap );
+			new SetWarpVisTypeAction( t, bw, bw.getViewerFrameP() ).put( actionMap );
+			new SetWarpVisTypeAction( t, bw, bw.getViewerFrameQ() ).put( actionMap );
 		}
 
-		map.put( new ResetActiveViewerAction( bw ));
-		map.put( new AlignViewerPanelAction( bw, AlignViewerPanelAction.TYPE.ACTIVE_TO_OTHER ) );
-		map.put( new AlignViewerPanelAction( bw, AlignViewerPanelAction.TYPE.OTHER_TO_ACTIVE ) );
-		map.put( new WarpToSelectedAction( bw ));
-		map.put( new WarpToNextAction( bw, true ));
-		map.put( new WarpToNextAction( bw, false ));
-		map.put( new WarpToNearest( bw ));
+		new ResetActiveViewerAction( bw ).put( actionMap );
+		new AlignViewerPanelAction( bw, AlignViewerPanelAction.TYPE.ACTIVE_TO_OTHER ).put( actionMap );
+		new AlignViewerPanelAction( bw, AlignViewerPanelAction.TYPE.OTHER_TO_ACTIVE ).put( actionMap );
+		new WarpToSelectedAction( bw ).put( actionMap );
+		new WarpToNextAction( bw, true ).put( actionMap );
+		new WarpToNextAction( bw, false ).put( actionMap );
+		new WarpToNearest( bw ).put( actionMap );
 
-		for( GridSource.GRID_TYPE t : GridSource.GRID_TYPE.values())
-			map.put( new SetWarpVisGridTypeAction( String.format( WARPVISGRID, t.name()), bw, t ));
+		for( final GridSource.GRID_TYPE t : GridSource.GRID_TYPE.values())
+			new SetWarpVisGridTypeAction( String.format( WARPVISGRID, t.name()), bw, t ).put( actionMap );
 
-		map.put( new SetBookmarkAction( bw ) );
-		map.put( new GoToBookmarkAction( bw ) );
-		map.put( new GoToBookmarkRotationAction( bw ) );
+		new SetBookmarkAction( bw ).put( actionMap );
+		new GoToBookmarkAction( bw ).put( actionMap );
+		new GoToBookmarkRotationAction( bw ).put( actionMap );
 
-		map.put( new SaveSettingsAction( bw ) );
-		map.put( new LoadSettingsAction( bw ) );
+		new SaveSettingsAction( bw ).put( actionMap );
+		new LoadSettingsAction( bw ).put( actionMap );
 
 		return actionMap;
 	}
 
-	public static InputMap createInputMap( final KeyProperties keyProperties )
+	public static InputMap createInputMap( final KeyStrokeAdder.Factory keyProperties )
 	{
 		final InputMap inputMap = new InputMap();
 		final KeyStrokeAdder map = keyProperties.keyStrokeAdder( inputMap );
@@ -230,33 +227,33 @@ public class BigWarpActions
 	public static ActionMap createActionMap( final BigWarp bw )
 	{
 		final ActionMap actionMap = new ActionMap();
-		final NamedActionAdder map = new NamedActionAdder( actionMap );
 
-		map.put( new LandmarkModeAction( LANDMARK_MODE_ON, bw, true ) );
-		map.put( new LandmarkModeAction( LANDMARK_MODE_OFF, bw, false ) );
+		new LandmarkModeAction( LANDMARK_MODE_ON, bw, true ).put( actionMap );
+		new LandmarkModeAction( LANDMARK_MODE_OFF, bw, false ).put( actionMap );
 
-		map.put( new ToggleDialogAction( SHOW_WARPTYPE_DIALOG, bw.warpVisDialog ) );
+		new ToggleDialogAction( SHOW_WARPTYPE_DIALOG, bw.warpVisDialog ).put( actionMap );
 
-		map.put( new ToggleDialogAction( BRIGHTNESS_SETTINGS, bw.brightnessDialog ) );
-		map.put( new ToggleDialogAction( SHOW_HELP, bw.helpDialog ) );
+		new ToggleDialogAction( BRIGHTNESS_SETTINGS, bw.brightnessDialog ).put( actionMap );
+		new ToggleDialogAction( SHOW_HELP, bw.helpDialog ).put( actionMap );
 
-		map.put( new TogglePointsVisibleAction( TOGGLE_POINTS_VISIBLE, bw ));
-		map.put( new TogglePointNameVisibleAction( TOGGLE_POINT_NAMES_VISIBLE, bw ));
-		map.put( new ToggleMovingImageDisplayAction( TOGGLE_MOVING_IMAGE_DISPLAY, bw ));
-		map.put( new EstimateWarpAction( ESTIMATE_WARP, bw ));
+		new TogglePointsVisibleAction( TOGGLE_POINTS_VISIBLE, bw ).put( actionMap );
+		new TogglePointNameVisibleAction( TOGGLE_POINT_NAMES_VISIBLE, bw ).put( actionMap );
+		new ToggleMovingImageDisplayAction( TOGGLE_MOVING_IMAGE_DISPLAY, bw ).put( actionMap );
+		new EstimateWarpAction( ESTIMATE_WARP, bw ).put( actionMap );
 
 		for( int i = 0; i < bw.baseXfmList.length; i++ ){
-			AbstractModel<?> xfm = bw.baseXfmList[ i ];
-			map.put( new SetWarpMagBaseAction( String.format( WARPMAG_BASE, xfm.getClass().getName()), bw, i ));
+			final AbstractModel<?> xfm = bw.baseXfmList[ i ];
+			new SetWarpMagBaseAction( String.format( WARPMAG_BASE, xfm.getClass().getName()), bw, i ).put( actionMap );
 		}
-		
-		map.put( new UndoRedoAction( UNDO, bw ) );
-		map.put( new UndoRedoAction( REDO, bw ) );
 
-		map.put( new TableSelectionAction( String.format( SELECT_TABLE_ROWS, -1 ), bw.getLandmarkPanel().getJTable(), -1 ) );
+		new UndoRedoAction( UNDO, bw ).put( actionMap );
+		new UndoRedoAction( REDO, bw ).put( actionMap );
 
-		map.put( new GarbageCollectionAction( GARBAGE_COLLECTION ) );
-		map.put( new DebugAction( DEBUG, bw ) );
+		new TableSelectionAction( String.format( SELECT_TABLE_ROWS, -1 ), bw.getLandmarkPanel().getJTable(), -1 ).put( actionMap );
+
+		new GarbageCollectionAction( GARBAGE_COLLECTION ).put( actionMap );
+		new DebugAction( DEBUG, bw ).put( actionMap );
+
 			
 		return actionMap;
 	}

--- a/src/main/java/bigwarp/BigWarpExporter.java
+++ b/src/main/java/bigwarp/BigWarpExporter.java
@@ -128,7 +128,8 @@ public class BigWarpExporter< T extends RealType< T > & NativeType< T >  >
 //		RandomAccessibleInterval< RealType< ? >> tmp = (RandomAccessibleInterval< RealType <? > > )sources.get( targetSourceIndexList[ 0 ] ).getSpimSource().getSource( 0, 0 );
 		
 		// go from physical space to fixed image space
-		final AffineTransform3D fixedImgXfm = sources.get( targetSourceIndexList[ 0 ] ).getSpimSource().getSourceTransform( 0, 0 );
+		final AffineTransform3D fixedImgXfm = new AffineTransform3D();
+		sources.get( targetSourceIndexList[ 0 ] ).getSpimSource().getSourceTransform( 0, 0, fixedImgXfm );
 		final AffineTransform3D fixedXfmInv = fixedImgXfm.inverse(); // get to the pixel space of the fixed image
 		
 		// TODO - 	require for now that all moving image types are the same.  
@@ -153,7 +154,8 @@ public class BigWarpExporter< T extends RealType< T > & NativeType< T >  >
 			final RealRandomAccessible< T > raiRaw = ( RealRandomAccessible< T > )sources.get( movingSourceIndex ).getSpimSource().getInterpolatedSource( 0, 0, interp );
 			
 			// go from moving to physical space
-			final AffineTransform3D movingImgXfm = sources.get( movingSourceIndex ).getSpimSource().getSourceTransform( 0, 0 );
+			final AffineTransform3D movingImgXfm = new AffineTransform3D();
+			sources.get( movingSourceIndex ).getSpimSource().getSourceTransform( 0, 0, movingImgXfm );
 
 			// apply the transformations
 			final AffineRandomAccessible< T, AffineGet > rai = RealViews.affine( RealViews.affine( raiRaw, movingImgXfm ), fixedXfmInv );

--- a/src/main/java/bigwarp/source/GridSource.java
+++ b/src/main/java/bigwarp/source/GridSource.java
@@ -111,12 +111,6 @@ public class GridSource< T extends RealType< T >> implements Source< T >
 //	}
 
 	@Override
-	public AffineTransform3D getSourceTransform(int t, int level)
-	{
-		return sourceData.sources.get( 0 ).getSpimSource().getSourceTransform( t, level );
-	}
-
-	@Override
 	public T getType()
 	{
 		return type;

--- a/src/main/java/bigwarp/source/WarpMagnitudeSource.java
+++ b/src/main/java/bigwarp/source/WarpMagnitudeSource.java
@@ -169,12 +169,6 @@ public class WarpMagnitudeSource< T extends RealType< T >> implements Source< T 
 	}
 
 	@Override
-	public AffineTransform3D getSourceTransform(int t, int level)
-	{
-		return sourceData.sources.get( 0 ).getSpimSource().getSourceTransform( t, level );
-	}
-
-	@Override
 	public T getType()
 	{
 		return type;


### PR DESCRIPTION
bump bdv versions to pom-bigdataviewer-4.0.1. This introduces API changes (mostly moving things around and removal of deprecated API) and this PR fixes resulting compile errors.