### PR TITLE
bugfix: allow deleting row 0 in the landmark table

### DIFF
--- a/src/main/java/bigwarp/landmarks/LandmarkTableModel.java
+++ b/src/main/java/bigwarp/landmarks/LandmarkTableModel.java
@@ -330,7 +330,7 @@ public class LandmarkTableModel extends AbstractTableModel {
 
 	public void deleteRow( int i )
 	{
-		if( getRowCount() > 0 && i > 0)
+		if( getRowCount() > 0 && i >= 0)
 		{
 			undoRedoManager.addEdit( new DeleteRowEdit( this, i ) );
 			deleteRowHelper( i );


### PR DESCRIPTION
landmark 0 couldn't be deleted because of wrong index check