### PR TITLE
BigWarpBatchTransform fixes and code cleanup

### DIFF
--- a/src/main/java/bigwarp/BigWarpBatchTransformFOV.java
+++ b/src/main/java/bigwarp/BigWarpBatchTransformFOV.java
@@ -1,8 +1,5 @@
 package bigwarp;
 
-import ij.IJ;
-import ij.ImagePlus;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -14,6 +11,30 @@ import org.janelia.utility.parse.ParseUtils;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 
+import bdv.img.TpsTransformWrapper;
+import bdv.img.WarpedSource;
+import bdv.spimdata.SequenceDescriptionMinimal;
+import bdv.spimdata.SpimDataMinimal;
+import bdv.spimdata.WrapBasicImgLoader;
+import bdv.viewer.Interpolation;
+import bdv.viewer.SourceAndConverter;
+import bigwarp.BigWarp.BigWarpData;
+import bigwarp.landmarks.LandmarkTableModel;
+import bigwarp.loader.ImagePlusLoader;
+import ij.IJ;
+import ij.ImagePlus;
+import jitk.spline.ThinPlateR2LogRSplineKernelTransform;
+import mpicbg.spim.data.generic.AbstractSpimData;
+import mpicbg.spim.data.generic.sequence.BasicSetupImgLoader;
+import mpicbg.spim.data.generic.sequence.BasicViewSetup;
+import mpicbg.spim.data.generic.sequence.ImgLoaderHint;
+import mpicbg.spim.data.generic.sequence.TypedBasicImgLoader;
+import mpicbg.spim.data.registration.ViewRegistration;
+import mpicbg.spim.data.registration.ViewRegistrations;
+import mpicbg.spim.data.sequence.Channel;
+import mpicbg.spim.data.sequence.FinalVoxelDimensions;
+import mpicbg.spim.data.sequence.TimePoint;
+import mpicbg.spim.data.sequence.TimePoints;
 import net.imglib2.FinalDimensions;
 import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
@@ -27,28 +48,6 @@ import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.ConstantUtils;
-import jitk.spline.ThinPlateR2LogRSplineKernelTransform;
-import mpicbg.spim.data.generic.AbstractSpimData;
-import mpicbg.spim.data.generic.sequence.BasicSetupImgLoader;
-import mpicbg.spim.data.generic.sequence.BasicViewSetup;
-import mpicbg.spim.data.generic.sequence.ImgLoaderHint;
-import mpicbg.spim.data.generic.sequence.TypedBasicImgLoader;
-import mpicbg.spim.data.registration.ViewRegistration;
-import mpicbg.spim.data.registration.ViewRegistrations;
-import mpicbg.spim.data.sequence.Channel;
-import mpicbg.spim.data.sequence.FinalVoxelDimensions;
-import mpicbg.spim.data.sequence.TimePoint;
-import mpicbg.spim.data.sequence.TimePoints;
-import bdv.img.TpsTransformWrapper;
-import bdv.img.WarpedSource;
-import bdv.spimdata.SequenceDescriptionMinimal;
-import bdv.spimdata.SpimDataMinimal;
-import bdv.spimdata.WrapBasicImgLoader;
-import bdv.viewer.Interpolation;
-import bdv.viewer.SourceAndConverter;
-import bigwarp.BigWarp.BigWarpData;
-import bigwarp.landmarks.LandmarkTableModel;
-import bigwarp.loader.ImagePlusLoader;
 
 public class BigWarpBatchTransformFOV
 {
@@ -122,7 +121,7 @@ public class BigWarpBatchTransformFOV
 		int nd = alg.dims.length;
 		if( alg.offset.length < 3 )
 		{
-			alg.offsetFull = fill( alg.offset, nd, 0.0 );
+			alg.offsetFull = fill( alg.offset, nd );
 		}
 		else
 		{
@@ -131,7 +130,7 @@ public class BigWarpBatchTransformFOV
 
 		if( alg.spacing.length < 3 )
 		{
-			alg.spacingFull = fill( alg.spacing, nd, 1.0 );
+			alg.spacingFull = fill( alg.spacing, nd );
 		}
 		else
 		{
@@ -176,7 +175,7 @@ public class BigWarpBatchTransformFOV
 
 		ImagePlus impP = IJ.openImage( imageFilePath );
 
-		String[] names = new String[]{ impP.getTitle(), "target_interval" };
+		String[] names = generateNames( impP );
 
 		/* Load the first source */
 		final ImagePlusLoader loaderP = new ImagePlusLoader( impP );
@@ -187,15 +186,21 @@ public class BigWarpBatchTransformFOV
 		BigWarpData data = BigWarpInit.createBigWarpData( spimDataP, spimDataQ, names );
 
 		Interpolation interpolation = Interpolation.valueOf( interpType );
-		int[] movingSourceIndexList = new int[]{ 0 };
-		int[] targetSourceIndexList = new int[]{ 1 };
+		int numChannels = impP.getNChannels();
+		System.out.println( numChannels + " channels" );
+		int[] movingSourceIndexList = new int[ numChannels ];
+		for ( int i = 0; i < numChannels; i++ )
+		{
+			movingSourceIndexList[ i ] = i;
+		}
+		int[] targetSourceIndexList = new int[] { numChannels };
 		ArrayList< SourceAndConverter< ? >> sourcesxfm = BigWarp.wrapSourcesAsTransformed(
 				data.sources, 
 				ltm.getNumdims(),
 				movingSourceIndexList );
 
 
-		InverseRealTransform irXfm = new InverseRealTransform( new TpsTransformWrapper( xfm.getNumDims(), xfm )); 
+		InverseRealTransform irXfm = new InverseRealTransform( new TpsTransformWrapper( 3, xfm ) );
 		((WarpedSource< ? >) (sourcesxfm.get( 0 ).getSpimSource())).updateTransform( irXfm );
 		((WarpedSource< ? >) (sourcesxfm.get( 0 ).getSpimSource())).setIsTransformed( true );
 
@@ -241,6 +246,17 @@ public class BigWarpBatchTransformFOV
 		long endTime = System.currentTimeMillis();
 		System.out.println( "total time: " + (endTime - startTime) + " ms");
 		System.exit( 0 );
+	}
+
+	public String[] generateNames( ImagePlus imp )
+	{
+		String[] names = new String[ imp.getNChannels() + 1 ];
+		for ( int i = 0; i < imp.getNChannels(); i++ )
+		{
+			names[ i ] = imp.getTitle();
+		}
+		names[ imp.getNChannels() ] = "target_interval";
+		return names;
 	}
 
 	public final SpimDataMinimal createSpimData()
@@ -298,18 +314,21 @@ public class BigWarpBatchTransformFOV
 		return spimData;
 	}
 
-	public static double[] fill( double[] in, int ndim, double zVal )
+	public static double[] fill( double[] in, int ndim )
 	{
 		double[] out = new double[ 3 ];
-		if( in.length == 1 && ndim == 2 )
+		if ( in.length == 1 )
 		{
 			Arrays.fill( out, in[ 0 ] );
-			out[ 2 ] = zVal;
 		}
-		else if( in.length == 2 && ndim == 2 )
+		else if ( in.length >= ndim )
 		{
 			System.arraycopy( in, 0, out, 0, 2 );
-			out[ 2 ] = zVal;
+		}
+		else
+		{
+			System.err.println( "Array length is less than dimensions!" );
+			return null;
 		}
 
 		return out;

--- a/src/main/java/bigwarp/BigWarpRealExporter.java
+++ b/src/main/java/bigwarp/BigWarpRealExporter.java
@@ -1,12 +1,12 @@
 package bigwarp;
 
-import ij.IJ;
-import ij.ImagePlus;
-import jitk.spline.XfmUtils;
-import mpicbg.spim.data.sequence.VoxelDimensions;
-
 import java.util.ArrayList;
 
+import bdv.viewer.Interpolation;
+import bdv.viewer.SourceAndConverter;
+import ij.IJ;
+import ij.ImagePlus;
+import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
@@ -35,11 +35,7 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Util;
-import net.imglib2.view.MixedTransformView;
 import net.imglib2.view.Views;
-import bdv.viewer.Interpolation;
-import bdv.viewer.SourceAndConverter;
 
 public class BigWarpRealExporter< T extends RealType< T > & NativeType< T >  > implements BigWarpExporter<T>
 {
@@ -90,6 +86,7 @@ public class BigWarpRealExporter< T extends RealType< T > & NativeType< T >  > i
 	}
 	
 
+	@Override
 	public void setInterp( Interpolation interp )
 	{
 		this.interp = interp;
@@ -119,11 +116,13 @@ public class BigWarpRealExporter< T extends RealType< T > & NativeType< T >  > i
 		return true;
 	}
 
+	@Override
 	public ImagePlus exportMovingImagePlus( final boolean isVirtual )
 	{
 		return exportMovingImagePlus( isVirtual, 1 );
 	}
 
+	@Override
 	@SuppressWarnings( { "unchecked" } )
 	public ImagePlus exportMovingImagePlus( final boolean isVirtual, final int nThreads )
 	{
@@ -231,14 +230,18 @@ public class BigWarpRealExporter< T extends RealType< T > & NativeType< T >  > i
 	{
 		// A bit of hacking to make slices the 4th dimension and channels the 3rd
 		// since that's how ImagePlusImgFactory does it
-		MixedTransformView< T > raip = Views.permute( rai, 2, 3 );
+		RandomAccessible< T > raip;
+		if ( rai.numDimensions() > 3 )
+			raip = Views.permute( rai, 2, 3 );
+		else
+			raip = rai;
 
 		final long[] dimensions = new long[ itvl.numDimensions() ];
 		for( int d = 0; d < itvl.numDimensions(); d++ )
 		{
-			if( d == 2 )
+			if ( d == 2 && itvl.numDimensions() > 3 )
 				dimensions[ d ] = itvl.dimension( 3 );
-			else if( d == 3 )
+			else if ( d == 3 && itvl.numDimensions() > 3 )
 				dimensions[ d ] = itvl.dimension( 2 );
 			else
 				dimensions[ d ] = itvl.dimension( d );
@@ -386,9 +389,9 @@ public class BigWarpRealExporter< T extends RealType< T > & NativeType< T >  > i
 		public void convert( ARGBType input, FloatType output )
 		{
 			int v = input.getIndex();
-			float r = ( float ) ARGBType.red( v );
-			float g = ( float ) ARGBType.green( v );
-			float b = ( float ) ARGBType.blue( v );
+			float r = ARGBType.red( v );
+			float g = ARGBType.green( v );
+			float b = ARGBType.blue( v );
 			output.set( r + g + b );
 		}
 


### PR DESCRIPTION
some fixes to problems that caused the command-line BigWarp (BigWarpBatchTransformFOV) to not work for two dimensional and multichannel images, and combining some redundant code in the BatchTransforms into a single static method