### PR TITLE
Small Fixes

### DIFF
--- a/src/main/java/bigwarp/BigWarp.java
+++ b/src/main/java/bigwarp/BigWarp.java
@@ -1622,15 +1622,15 @@ public class BigWarp
 			}
 
 		}
-
-		int offImgIndex = 0;
-		int onImgIndex = 1;
-
-		if ( viewerFrame == viewerFrameP )
-		{
-			offImgIndex = 1;
-			onImgIndex = 0;
-		}
+//
+//		int offImgIndex = 0;
+//		int onImgIndex = 1;
+//
+//		if ( viewerFrame == viewerFrameP )
+//		{
+//			offImgIndex = 1;
+//			onImgIndex = 0;
+//		}
 
 		if ( landmarkModel.getTransform() == null )
 		{
@@ -1646,7 +1646,7 @@ public class BigWarp
 			// turn warp mag on
 			vg.setSourceActive( warpMagSourceIndex, true );
 			vg.setSourceActive( gridSourceIndex, false );
-			vg.setSourceActive( offImgIndex, false );
+//			vg.setSourceActive( offImgIndex, false );
 
 			// estimate the max warp
 			final WarpMagnitudeSource< ? > wmSrc = ( ( WarpMagnitudeSource< ? > ) sources.get( warpMagSourceIndex ).getSpimSource() );
@@ -1656,17 +1656,20 @@ public class BigWarp
 			( ( RealARGBColorConverter< FloatType > ) ( sources.get( warpMagSourceIndex ).getConverter() ) ).setMax( maxval );
 
 			vg.setFusedEnabled( true );
+			vg.setGroupingEnabled( false );
 			viewerFrame.getViewerPanel().showMessage( "Displaying Warp Magnitude" );
 			break;
 		}
 		case GRID:
 		{
 			// turn grid vis on
+			
 			vg.setSourceActive( warpMagSourceIndex, false );
 			vg.setSourceActive( gridSourceIndex, true );
-			vg.setSourceActive( offImgIndex, false );
+//			vg.setSourceActive( offImgIndex, false );
 
 			vg.setFusedEnabled( true );
+			vg.setGroupingEnabled( false );
 			viewerFrame.getViewerPanel().showMessage( "Displaying Warp Grid" );
 			break;
 		}
@@ -1674,9 +1677,9 @@ public class BigWarp
 		{
 			vg.setSourceActive( warpMagSourceIndex, false );
 			vg.setSourceActive( gridSourceIndex, false );
-			vg.setSourceActive( offImgIndex, true );
+//			vg.setSourceActive( offImgIndex, true );
 
-			vg.setFusedEnabled( false );
+//			vg.setFusedEnabled( false );
 			viewerFrame.getViewerPanel().showMessage( "Turning off warp vis" );
 			break;
 		}
@@ -1685,8 +1688,8 @@ public class BigWarp
 
 	public void toggleWarpVisMode( BigWarpViewerFrame viewerFrame )
 	{
-		int offImgIndex = 0;
-		int onImgIndex = 1;
+//		int offImgIndex = 0;
+//		int onImgIndex = 1;
 		if ( viewerFrame == null )
 		{
 			if ( viewerFrameP.isActive() )
@@ -1701,11 +1704,11 @@ public class BigWarp
 				return;
 		}
 
-		if ( viewerFrame == viewerFrameP )
-		{
-			offImgIndex = 1;
-			onImgIndex = 0;
-		}
+//		if ( viewerFrame == viewerFrameP )
+//		{
+//			offImgIndex = 1;
+//			onImgIndex = 0;
+//		}
 
 		if ( landmarkModel.getTransform() == null )
 		{
@@ -1723,7 +1726,7 @@ public class BigWarp
 		{
 			vg.setSourceActive( warpMagSourceIndex, false );
 
-			vg.setSourceActive( offImgIndex, true );
+//			vg.setSourceActive( offImgIndex, true );
 
 			vg.setFusedEnabled( false );
 			viewerFrame.getViewerPanel().showMessage( "Removing Warp Magnitude" );
@@ -1731,7 +1734,7 @@ public class BigWarp
 		else // warp mag is invisible, turn it on
 		{
 			vg.setSourceActive( warpMagSourceIndex, true );
-			vg.setSourceActive( offImgIndex, false );
+//			vg.setSourceActive( offImgIndex, false );
 
 			// estimate the max warp
 			final WarpMagnitudeSource< ? > wmSrc = ( ( WarpMagnitudeSource< ? > ) sources.get( warpMagSourceIndex ).getSpimSource() );

--- a/src/main/java/bigwarp/BigWarpBatchTransformFOV.java
+++ b/src/main/java/bigwarp/BigWarpBatchTransformFOV.java
@@ -257,13 +257,16 @@ public class BigWarpBatchTransformFOV
 
 	public static String[] generateNames( ImagePlus imp )
 	{
-		String[] names = new String[ imp.getNChannels() + 1 ];
-		for ( int i = 0; i < imp.getNChannels(); i++ )
+		String[] namesWithTarget = new String[ imp.getNChannels() + 1 ];
+		String[] names = BigWarpInit.namesFromImagePlus(imp);
+		
+		for(int i = 0; i < names.length; i ++)
 		{
-			names[ i ] = imp.getTitle();
+			namesWithTarget[i] = names[i];
 		}
-		names[ imp.getNChannels() ] = "target_interval";
-		return names;
+		
+		namesWithTarget[ imp.getNChannels() ] = "target_interval";
+		return namesWithTarget;
 	}
 
 	public final SpimDataMinimal createSpimData()

--- a/src/main/java/bigwarp/BigWarpInit.java
+++ b/src/main/java/bigwarp/BigWarpInit.java
@@ -2,14 +2,12 @@ package bigwarp;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import bdv.BigDataViewer;
 import bdv.SpimSource;
 import bdv.VolatileSpimSource;
 import bdv.img.RenamableSource;
-import bdv.img.WarpedSource;
 import bdv.spimdata.WrapBasicImgLoader;
 import bdv.tools.brightness.ConverterSetup;
 import bdv.tools.brightness.RealARGBColorConverterSetup;
@@ -391,6 +389,7 @@ public class BigWarpInit
 	{
 		File fP = new File( xmlFilenameP );
 		File fQ = new File( xmlFilenameQ );
+		// TODO: wrong when XMLLoaders return multichannel sources
 		return createBigWarpData( new XMLLoader( xmlFilenameP ), new XMLLoader( xmlFilenameQ ),
 				new String[]{ fP.getName(), fQ.getName() });
 	}
@@ -404,7 +403,7 @@ public class BigWarpInit
 	 */
 	public static BigWarpData createBigWarpDataFromImages( final ImagePlus impP, final ImagePlus impQ )
 	{
-		String[] names = new String[]{ impP.getTitle(), impQ.getTitle() };
+		String[] names = namesFromImagePluses(impP, impQ);
 		return createBigWarpData( new ImagePlusLoader( impP ), new ImagePlusLoader( impQ ), names );
 	}
 
@@ -490,5 +489,47 @@ public class BigWarpInit
 	public static BigWarpData createBigWarpDataFromImagePlusXML( final ImagePlus[] impP, final String xmlFilenameQ )
 	{
 		return createBigWarpData( new ImagePlusLoader( impP ), new XMLLoader( xmlFilenameQ ) );
+	}
+	
+	
+	/**
+	 * Create a {@link String} array of names from two {@link ImagePlus}es, essentially
+	 * concatenating the results from calling {@link namesFromImagePlus} with each.
+	 *
+	 * @param impP first image to generate names from
+	 * @param impQ second image to generate names from
+	 * @return String array of names from both images
+	 */
+	public static String[] namesFromImagePluses(ImagePlus impP, ImagePlus impQ) {
+		String[] names = new String[impP.getNChannels() + impQ.getNChannels()];
+
+		String[] impPnames = namesFromImagePlus(impP);
+		String[] impQnames = namesFromImagePlus(impP);
+
+		int i = 0;
+		for(String name : impPnames)
+			names[i++] = name;
+		for(String name : impQnames)
+			names[i++] = name;
+
+		return names;
+	}
+
+	/**
+	 * Create a {@link String} array of names from an {@link ImagePlus}. Each channel
+	 * is given its own name, in the format of [title]-[channel #], unless there is
+	 * only one channel.
+	 *
+	 * @param imp image to generate names from
+	 * @return String array of names
+	 */
+	public static String[] namesFromImagePlus(ImagePlus imp)
+	{
+		if(imp.getNChannels() == 1)
+			return new String[] { imp.getTitle() };
+		String[] names = new String[imp.getNChannels()];
+		for(int i = 0; i < names.length; ++i)
+			names[i] = imp.getTitle() + "-" + i;
+		return names;
 	}
 }


### PR DESCRIPTION
Fixes #38 by adding helper method to generate names from `ImagePlus` (problem was that it was only generating one name per `ImagePlus`, when it needed one for each channel)

Also, when grid or warp magnitude is turned on, grouping mode is now disabled (so that they actually display on multichannel images).

Commented out `onImgIndex` and `offImgIndex` as they were only for convenience and are incompatible with multichannel images (would need a list of indices, or at least more complicated logic)