### PR TITLE
TpsTransformWrapper fixes

### DIFF
--- a/src/main/java/bdv/img/TpsTransformWrapper.java
+++ b/src/main/java/bdv/img/TpsTransformWrapper.java
@@ -80,7 +80,19 @@ public class TpsTransformWrapper implements InvertibleRealTransform, Serializabl
 	}
 
 	@Override
-	public void apply( final float[] source, final float[] target ){}
+	public void apply( final float[] source, final float[] target )
+	{
+		double[] sourceDouble = new double[ source.length ];
+		for ( int d = 0; d < source.length; ++d )
+			sourceDouble[ d ] = source[ d ];
+
+		double[] guessDouble = tps.initialGuessAtInverse( sourceDouble );
+		double error = tps.inverseTol( sourceDouble, guessDouble, invTolerance, invMaxIters );
+//		System.out.println( "error: " + error );
+
+		for ( int d = 0; d < target.length; ++d )
+			target[ d ] = ( float ) guessDouble[ d ];
+	}
 
 	@Override
 	public void apply( final RealLocalizable source, final RealPositionable target )

--- a/src/main/java/bdv/img/TpsTransformWrapper.java
+++ b/src/main/java/bdv/img/TpsTransformWrapper.java
@@ -73,6 +73,12 @@ public class TpsTransformWrapper implements InvertibleRealTransform, Serializabl
 	@Override
 	public void apply( final double[] source, final double[] target )
 	{ 
+		if ( tps == null )
+		{
+			System.arraycopy( source, 0, target, 0, target.length );
+			return;
+		}
+
 		double[] guess = tps.initialGuessAtInverse( source );
 		double error = tps.inverseTol( source, guess, invTolerance, invMaxIters );
 //		System.out.println( "error: " + error );
@@ -82,6 +88,12 @@ public class TpsTransformWrapper implements InvertibleRealTransform, Serializabl
 	@Override
 	public void apply( final float[] source, final float[] target )
 	{
+		if ( tps == null )
+		{
+			System.arraycopy( source, 0, target, 0, target.length );
+			return;
+		}
+
 		double[] sourceDouble = new double[ source.length ];
 		for ( int d = 0; d < source.length; ++d )
 			sourceDouble[ d ] = source[ d ];


### PR DESCRIPTION
- Add missing `apply()` implementation for `float` coordinates
- Fix `apply()` as identity transform when `tps` is `null`