### PR TITLE
Remove conda installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,3 @@ If you are using this tool in your work, please do not forget to cite [John Bogo
 JA Bogovic, P Hanslovsky, A Wong, S Saalfeld, "Robust registration of calcium images by learned contrast synthesis", In *Biomedical Imaging (ISBI)*, 2016 IEEE 13th International Symposium on, 1123-1126,  DOI: [10.1109/ISBI.2016.7493463](https://doi.org/10.1109/ISBI.2016.7493463).
 
 See the main [bigwarp page](http://fiji.sc/BigWarp) for details.
-
-Also available on conda as standalone version outside of Fiji:
-```
-# Installation
-conda install -c hanslovsky bigwarp
-
-# Run
-bigwarp <moving-image> <target-image> <optional-landmarks>
-```


### PR DESCRIPTION
I cleaned up my conda channel and removed old packages that may not work anymore because of outdated dependencies, bigwarp was one of them.

This is the recipe that I used and that would be updated to use jgo instead of jrun:
https://github.com/hanslovsky/conda-build-scripts/tree/3ecfea25917abf4338808eb0a2317986d21a6930/bigwarp