### PR TITLE
Update to bigdataviewer-core 9.0.1 and fix compile errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>28.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -111,9 +111,9 @@
 
 		<ejml.version>0.24</ejml.version>
 		<jcommander.version>1.48</jcommander.version>
-		<bigdataviewer-core.version>7.0.0</bigdataviewer-core.version>
-		<bigdataviewer_fiji.version>6.0.0</bigdataviewer_fiji.version>
-		<bigdataviewer-vistools.version>1.0.0-beta-15</bigdataviewer-vistools.version>
+		<bigdataviewer-core.version>9.0.1</bigdataviewer-core.version>
+		<bigdataviewer_fiji.version>6.1.0</bigdataviewer_fiji.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-20</bigdataviewer-vistools.version>
         <jitk-tps.version>3.0.1</jitk-tps.version>
         <imglib2-realtransform.version>3.0.0</imglib2-realtransform.version>
 

--- a/src/main/java/bdv/viewer/BigWarpConverterSetupWrapper.java
+++ b/src/main/java/bdv/viewer/BigWarpConverterSetupWrapper.java
@@ -3,22 +3,30 @@ package bdv.viewer;
 import net.imglib2.type.numeric.ARGBType;
 import bdv.tools.brightness.ConverterSetup;
 import bigwarp.BigWarp;
+import org.scijava.listeners.Listeners;
 
+@Deprecated
 public class BigWarpConverterSetupWrapper implements ConverterSetup {
 
 	protected ConverterSetup cs;
 	protected BigWarp bw;
-	
+
 	public BigWarpConverterSetupWrapper( BigWarp bw, ConverterSetup cs )
 	{
 		this.bw = bw;
 		this.cs = cs;
 	}
-	
+
 	public ConverterSetup getSourceConverterSetup(){
 		return cs;
 	}
-	
+
+	@Override
+	public Listeners< SetupChangeListener > setupChangeListeners()
+	{
+		return cs.setupChangeListeners();
+	}
+
 	@Override
 	public int getSetupId() {
 		return cs.getSetupId();
@@ -44,7 +52,7 @@ public class BigWarpConverterSetupWrapper implements ConverterSetup {
 		cs.setDisplayRange(min, max);
 		bw.getViewerFrameP().getViewerPanel().requestRepaint();
 		bw.getViewerFrameQ().getViewerPanel().requestRepaint();
-		
+
 	}
 
 	@Override
@@ -64,11 +72,4 @@ public class BigWarpConverterSetupWrapper implements ConverterSetup {
 	{
 		return cs.getDisplayRangeMax();
 	}
-
-	@Override
-	public void setViewer( RequestRepaint arg0 )
-	{
-		// do nothing
-	}
-
 }

--- a/src/main/java/bigwarp/BigWarp.java
+++ b/src/main/java/bigwarp/BigWarp.java
@@ -495,11 +495,15 @@ public class BigWarp< T >
 		landmarkPopupMenu = new LandmarkPointMenu( this );
 		landmarkPopupMenu.setupListeners();
 
-		final ArrayList< ConverterSetup > csetups = new ArrayList< ConverterSetup >();
 		for ( final ConverterSetup cs : converterSetups )
-			csetups.add( new BigWarpConverterSetupWrapper( this, cs ) );
+		{
+			cs.setupChangeListeners().add( s -> {
+				viewerP.requestRepaint();
+				viewerQ.requestRepaint();
+			} );
+		}
 
-		setupAssignments = new SetupAssignments( csetups, 0, 65535 );
+		setupAssignments = new SetupAssignments( new ArrayList<>( converterSetups ), 0, 65535 );
 
 		brightnessDialog = new BrightnessDialog( landmarkFrame, setupAssignments );
 		helpDialog = new HelpDialog( landmarkFrame );


### PR DESCRIPTION
Update to bigdataviewer-core 9.0.1.
This PR only updates dependencies and fixes a compile error.
(No changes to use BDV's new ViewerState API or Panel UI are made so far...)